### PR TITLE
express functions and typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,15 +1,14 @@
 const express = require('express');
-const bodyParser = require('body-parser');
 const chalk = require('chalk');
-const middelware = require('./routers/middleware')
+const middleware = require('./routers/middleware')
 const apis = require('./routers/apis');
 
 const app = express();
 const path = 8080;
 
-app.use(bodyParser.json())
-app.use(bodyParser.urlencoded({ extended: true }))
-app.use(middelware);
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+app.use(middleware);
 app.use(apis);
 
 app.listen(path,()=>{


### PR DESCRIPTION
borrado de la importacion del modulo body-parser, para usar las funciones de express (ya que son recomendadas por el mismo paquete)
typo en middelware => middleware